### PR TITLE
Add Azure Identity package and implement conditional credential selection

### DIFF
--- a/infrastructure/services/cognitive-search/index.ts
+++ b/infrastructure/services/cognitive-search/index.ts
@@ -1,3 +1,4 @@
+import { DefaultAzureCredential, DefaultAzureCredentialOptions, TokenCredential } from '@azure/identity';
 import { SearchIndexClient, SearchClient, AzureKeyCredential, SearchIndex, SearchDocumentsResult } from '@azure/search-documents';
 
 export interface ICognitiveSearch {
@@ -19,7 +20,19 @@ export class CognitiveSearch implements ICognitiveSearch {
     return value;
   }
   constructor(searchKey: string, endpoint: string) {
-    const credentials = new AzureKeyCredential(searchKey);
+    let credentials : TokenCredential;
+    
+    if(process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"){
+      credentials = new DefaultAzureCredential();
+      console.log('Using AzureCliCredential');
+      console.log('stringified credentials', JSON.stringify(credentials));
+    } else if (process.env.MANAGED_IDENTITY_CLIENT_ID !== undefined) {
+      credentials = new DefaultAzureCredential({ ManangedIdentityClientId: process.env.MANAGED_IDENTITY_CLIENT_ID } as DefaultAzureCredentialOptions);
+    } else {
+      credentials = new DefaultAzureCredential();
+    }
+
+    //const credentials = new AzureKeyCredential(searchKey);
     this.client = new SearchIndexClient(endpoint, credentials);
   }
 

--- a/infrastructure/services/cognitive-search/index.ts
+++ b/infrastructure/services/cognitive-search/index.ts
@@ -24,15 +24,12 @@ export class CognitiveSearch implements ICognitiveSearch {
     
     if(process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"){
       credentials = new DefaultAzureCredential();
-      console.log('Using AzureCliCredential');
-      console.log('stringified credentials', JSON.stringify(credentials));
     } else if (process.env.MANAGED_IDENTITY_CLIENT_ID !== undefined) {
       credentials = new DefaultAzureCredential({ ManangedIdentityClientId: process.env.MANAGED_IDENTITY_CLIENT_ID } as DefaultAzureCredentialOptions);
     } else {
       credentials = new DefaultAzureCredential();
     }
 
-    //const credentials = new AzureKeyCredential(searchKey);
     this.client = new SearchIndexClient(endpoint, credentials);
   }
 


### PR DESCRIPTION
This pull request adds the Azure Identity package and implements conditional credential selection based on the environment. It uses the DefaultAzureCredential class to select the appropriate credential based on the environment variables. If the environment is set to development or test, it uses the AzureCliCredential. If the MANAGED_IDENTITY_CLIENT_ID environment variable is defined, it uses the ManagedIdentityCredential with the specified client ID. Otherwise, it falls back to the DefaultAzureCredential.