### PR TITLE
Fix async issue in createCommunity method

### DIFF
--- a/screenplay/abilities/domain/interact-with-the-domain.ts
+++ b/screenplay/abilities/domain/interact-with-the-domain.ts
@@ -217,11 +217,11 @@ export class InteractWithTheDomain extends Ability
 
   public async createCommunity(communityName: string): Promise<CommunityProps> {
     let community: CommunityProps;
-    InteractWithTheDomain._database.CommunityUnitOfWork.withTransaction(this.context, async (repo) => {
+    await InteractWithTheDomain._database.CommunityUnitOfWork.withTransaction(this.context, async (repo) => {
         const user: UserEntityReference = await this.getOrCreateUserForActor(actorInTheSpotlight());
         const communityToBeSaved = await repo.getNewInstance(communityName, user);
         const savedCommunity = await repo.save(communityToBeSaved);
-         community  = savedCommunity['props'] as CommunityProps;
+        community  = savedCommunity['props'];
     });
     return community;
   }


### PR DESCRIPTION
This pull request fixes an async issue in the createCommunity method. Previously, the method was not awaited, causing potential race conditions. This PR adds the necessary await keyword to ensure the method is properly awaited.