### PR TITLE
Refactor step definition for registering an account in OwnerCommunity

### DIFF
--- a/features/community.feature
+++ b/features/community.feature
@@ -1,7 +1,7 @@
 Feature: Create a new community
 
   Scenario: Create a new community
-    Given OctaviaTheOwner registers an account in OwnerCommunity
+    Given OctaviaTheOwner has a registered account in OwnerCommunity
     When she creates a new community called MyCommunity
     Then she should see that the MyCommunity community was created by her
     And she is a member of MyCommunity

--- a/features/step-definitions/community.steps.ts
+++ b/features/step-definitions/community.steps.ts
@@ -6,7 +6,7 @@ import { CreateCommunity } from '../../screenplay/tasks/create-community';
 import { MemberInDb } from '../../screenplay/questions/member-in-db';
 import { CommunityInDb } from '../../screenplay/questions/community-in-db';
 
-Given('{actor} registers an account in OwnerCommunity', async function (actor: Actor) {
+Given('{actor} has a registered account in OwnerCommunity', async function (actor: Actor) {
   console.log(`Actor: ${actor}`);
 
   await actor


### PR DESCRIPTION
This pull request refactors the step definition for registering an account in OwnerCommunity. The given step has been updated from "Given OctaviaTheOwner registers an account in OwnerCommunity" to "Given OctaviaTheOwner has a registered account in OwnerCommunity". This change improves the clarity and readability of the step definition.