### PR TITLE
Add scenario for creating a new property

### DIFF
--- a/features/property.feature
+++ b/features/property.feature
@@ -1,0 +1,8 @@
+Feature: Create a new property
+
+  Scenario: Create a new property
+      The Given step definition is in file community.steps.ts
+    Given OmarTheOwner has a registered account in OwnerCommunity
+    And he is a member of a community
+    When he creates the property Pavilion in the community
+    Then the property Pavilion created by him exists in the community

--- a/features/step-definitions/property.steps.ts
+++ b/features/step-definitions/property.steps.ts
@@ -1,0 +1,30 @@
+import { Given, When, Then, DataTable } from '@cucumber/cucumber';
+import { Register } from '../../screenplay/tasks/register';
+import { Actor } from '@serenity-js/core';
+import { CreateCommunity } from '../../screenplay/tasks/create-community';
+import { CreateProperty } from '../../screenplay/tasks/create-property';
+import { PropertyInDb } from '../../screenplay/questions/property-in-db';
+import { Ensure, isPresent, equals} from '@serenity-js/assertions';
+
+const communityName = 'myCommunity';
+
+Given('{pronoun} is a member of a community', async function (actor: Actor) {
+  await actor
+    .attemptsTo(
+      CreateCommunity.named(communityName)    
+      );
+});
+
+When('{pronoun} creates the property {word} in the community', async function (actor: Actor, propertyName: string) {
+  await actor
+    .attemptsTo(
+      CreateProperty.inCommunity(communityName).asNewPropertyNamed(propertyName)
+      );
+});
+
+Then('the property {word} created by {pronoun} exists in the community', async function (propertyName: string, actor: Actor) {
+  await actor
+    .attemptsTo(
+      Ensure.that((await PropertyInDb(propertyName)).community.name, equals(communityName))
+    );
+});

--- a/features/support/actors.steps.ts
+++ b/features/support/actors.steps.ts
@@ -12,7 +12,7 @@ defineParameterType({
 
 defineParameterType({
     name: 'pronoun',
-    regexp: /he|she|they|his|her|their/,
+    regexp: /he|she|his|hers|him|her|they|their|them/,
     transformer() {
         return actorInTheSpotlight();
     },

--- a/screenplay/questions/property-in-db.ts
+++ b/screenplay/questions/property-in-db.ts
@@ -1,0 +1,11 @@
+import { Question } from '@serenity-js/core/lib/screenplay';
+import { InteractWithTheDomain } from '../abilities/domain/interact-with-the-domain';
+import { PropertyProps } from '../../domain/contexts/property/property';
+
+export const PropertyInDb = async (propertyName: string) => Question.about(`read ${propertyName} property`, async (actor) => {
+   let property: PropertyProps;
+   await InteractWithTheDomain.asReadOnly().readPropertyDb(async (db) => {
+      property = (db.getAll()).find((p) => p.propertyName === propertyName);
+   });
+   return property;
+});


### PR DESCRIPTION
This pull request adds a new scenario for creating a property in the community. The scenario is implemented in the `community.steps.ts` file and includes steps for registering a user, creating a community, and creating a property. Additionally, a new question `PropertyInDb` is added to retrieve the created property from the database.